### PR TITLE
Cleanup require metadata

### DIFF
--- a/snyk_sync/api.py
+++ b/snyk_sync/api.py
@@ -1,24 +1,17 @@
-import json
 import logging
-from types import new_class
-from uuid import RESERVED_FUTURE, UUID
-import yaml
 import urllib.parse
 
 import requests
 import time
 from retry.api import retry_call
 
-from pathlib import Path
-from pprint import pprint
-from dataclasses import dataclass
 from datetime import datetime
 
-from github import Github, Repository
+from github import Github
 
-from typing import Optional, List, Optional, TypedDict, Tuple, Dict
+from typing import Optional, List, Optional, Dict
 
-from pydantic import BaseModel, FilePath, ValidationError, root_validator, UUID4, Field, create_model
+from pydantic import BaseModel
 
 from snyk import SnykClient
 

--- a/snyk_sync/models/sync.py
+++ b/snyk_sync/models/sync.py
@@ -1,16 +1,10 @@
 import json
-import yaml
 
 from pathlib import Path
 from datetime import datetime
 from typing import Optional, List, Dict
-from pydantic import BaseModel, UUID4, error_wrappers, validator
+from pydantic import BaseModel, UUID4, error_wrappers
 from github import Repository
-
-from pathlib import Path
-
-
-from pprint import pprint
 
 from .repositories import Project, Repo, Branch
 
@@ -219,3 +213,7 @@ class SnykWatchList(BaseModel):
         org = orgs[0][1]
 
         return org
+
+    # removes repositories that don't exist in github anymore
+    def prune(self, repo_ids: list):
+        self.repos = [r for r in self.repos if r.id in repo_ids]

--- a/snyk_sync/utils.py
+++ b/snyk_sync/utils.py
@@ -13,9 +13,9 @@ from pathlib import Path
 
 from uuid import UUID
 
-from os import environ
+from os import environ, path
 
-from models.sync import Settings
+from models.sync import Settings, SnykWatchList, Repo
 
 
 V3_VERS = "2021-08-20~beta"
@@ -290,3 +290,18 @@ def ensure_dir(directory: Path) -> bool:
     else:
         # the directory exists and is OK
         return True
+
+
+def load_watchlist(cache_dir: Path) -> SnykWatchList:
+    tmp_watchlist = SnykWatchList()
+
+    if path.exists(f"{cache_dir}/data.json"):
+        try:
+            cache_data = jopen(f"{cache_dir}/data.json")
+            for r in cache_data:
+                tmp_watchlist.repos.append(Repo.parse_obj(r))
+
+        except KeyError as e:
+            print(e)
+
+    return tmp_watchlist


### PR DESCRIPTION
This adds both a --require-metadata and --include-archived flags to the targets command

--required-metadata only outputs the target list if there is an import.yaml file (or an import sha store) and --include-archived includes targets for archived repositories, by default snyk sync no longer imports those.

Because loading metadata for large numbers of repositories (a file call per repo) can consume a lot of API calls, the metadata is now only refreshed if the sha has changed, otherwise it will use the cached data. This behavior also means that the watchlist itself is shared between syncs, even if the session is told to refresh it - to prevent deleted / missing repos from being added to the list (or not be pruned properly), the data.json is pruned by repo id's discovered in a sync session each time a sync is run. 