### PR TITLE
Fix: change repo org regardless of repo updated_at

### DIFF
--- a/snyk_sync/models/sync.py
+++ b/snyk_sync/models/sync.py
@@ -122,12 +122,12 @@ class SnykWatchList(BaseModel):
 
                 existing_repo.archived = archived
 
-                if org_name != "default":
-                    existing_repo.org = org_name
-
                 existing_repo.branches = branches
 
                 existing_repo.updated_at = str(repo.updated_at)
+
+            if existing_repo.org != org_name and org_name != "default":
+                existing_repo.org = org_name
 
         else:
             try:


### PR DESCRIPTION
The logic to update an cached repository's organization was gated behind a check to see whether the `updated_at` repo field changed.

However, the Snyk organization field can change independent of a repository being updated. This fix ensures that the organization can be updated for a change outside of GitHub; for example, adding a topic to a `snyk-orgs.yml` file.