### PR TITLE
stop dynamic version lookup

### DIFF
--- a/snyk_sync/__version__.py
+++ b/snyk_sync/__version__.py
@@ -1,4 +1,1 @@
-import importlib.metadata
-
-
-__version__ = importlib.metadata.version("snyk-sync")
+__version__ = "0.3.0"


### PR DESCRIPTION
We attempted to be smart and load the version info from a snyk-sync package number, which worked locally, but wouldn't work properly for a none built poetry package in a container. So now it's just hard coded in __version__.py for the short term.